### PR TITLE
Add extra config options

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -2,6 +2,7 @@ infra_lock_file: /tmp/infmgr.lock
 
 # Proxmox API details
 host: proxmox.example.com
+# port: 8006
 user: api@pve
 password: verysecure
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -6,6 +6,10 @@ host: proxmox.example.com
 user: api@pve
 password: verysecure
 
+# Use a token instead of a password for authentication
+# token_name: name
+# token_secret: 000-000-...
+
 # Current = Determine load based on current resource usage
 # Max = Determine load based on maximum assigned resource
 method: current

--- a/proxmoxbalancer/proxmoxbalancer.py
+++ b/proxmoxbalancer/proxmoxbalancer.py
@@ -59,14 +59,26 @@ class ProxmoxBalancer:
                 sys.exit(1)
 
         self.config = config
-        self.proxmox = ProxmoxAPI(
-            config["host"],
-            port=config["port"],
-            user=config["user"],
-            password=config["password"],
-            backend="https",
-            verify_ssl=False,
-        )
+
+        if "token_name" in config and "token_secret" in config:
+            self.proxmox = ProxmoxAPI(
+                    config["host"],
+                    port=config["port"],
+                    user=config["user"],
+                    token_name=config["token_name"],
+                    token_value=config["token_secret"],
+                    backend="https",
+                    verify_ssl=False,
+                    )
+        else:
+            self.proxmox = ProxmoxAPI(
+                    config["host"],
+                    port=config["port"],
+                    user=config["user"],
+                    password=config["password"],
+                    backend="https",
+                    verify_ssl=False,
+                    )
 
     # Get various useful sum.
     def get_totals(self):

--- a/proxmoxbalancer/proxmoxbalancer.py
+++ b/proxmoxbalancer/proxmoxbalancer.py
@@ -52,6 +52,8 @@ class ProxmoxBalancer:
                     config["async"] = True
                 if "separate" not in config["rules"]:
                     config["rules"]["separate"] = {}
+                if "port" not in config:
+                    config["port"] = 8006
             except yaml.YAMLError as exc:
                 print(exc)
                 sys.exit(1)
@@ -59,6 +61,7 @@ class ProxmoxBalancer:
         self.config = config
         self.proxmox = ProxmoxAPI(
             config["host"],
+            port=config["port"],
             user=config["user"],
             password=config["password"],
             backend="https",


### PR DESCRIPTION
- Use a non-default port to the pve-API
- Use an API token instead of a password (https://pve.proxmox.com/wiki/Proxmox_VE_API#API_Tokens)